### PR TITLE
fix: ci release no verify [Release create-brain-app] v0.1.3

### DIFF
--- a/packages/create-brain-app/.release-it.json
+++ b/packages/create-brain-app/.release-it.json
@@ -3,6 +3,7 @@
     "requireUpstream": true,
     "commit": true,
     "commitMessage": "chore(tag): create-brain-app v${version}",
+    "commitArgs": ["--no-verify"],
     "tag": true,
     "tagName": "create-brain-app-v${version}",
     "tagMatch": "create-brain-app-v*",

--- a/packages/create-brain-app/package.json
+++ b/packages/create-brain-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-brain-app",
   "description": "A create-app tool for brainai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "private": false,
   "homepage": "https://github.com/qlover/brainai-frontend#readme",


### PR DESCRIPTION
1. Fix ci release commit no verify, release-it json add npm.git.commitArgs --no-verify
2. release create-brain-app v0.1.3